### PR TITLE
XIVY-17140 corrects doc for ivy-branding

### DIFF
--- a/source/designer-guide/user-interface/branding/includes/ivy-branding.xhtml
+++ b/source/designer-guide/user-interface/branding/includes/ivy-branding.xhtml
@@ -5,4 +5,4 @@
 <p:graphicImage name="logo" library="ivy-branding" alt="Logo" />
 
 <!-- custom.css -->
-<h:outputStylesheet name="colors.css" library="ivy-branding" />
+<h:outputStylesheet name="custom.css" library="ivy-branding" />


### PR DESCRIPTION
Changes "colors.css" to "custom.css" as it is the correct name for the ivy-branding-css.