### PR TITLE
Fix sphinx warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,6 @@ pipeline {
 
           withChecks('Doc Sphinx Issues-JA') {
             recordIssues tools: [sphinxBuild(id: 'sphinx-JA', name: 'Sphinx JA')], 
-              filters: [excludeFile('source/designer-guide/process-modeling/process-elements/trigger-step.rst')], 
               qualityGates: [[threshold: 1, type: 'TOTAL']]
           }
 

--- a/locale/ja/LC_MESSAGES/user-guide.po
+++ b/locale/ja/LC_MESSAGES/user-guide.po
@@ -13060,7 +13060,7 @@ msgstr "|image0| *トリガーステップ* 要素は、プロセスエディタ
 
 #: ../../source/designer-guide/process-modeling/process-elements/trigger-step.rst:12
 msgid "With the Trigger element its possible to start a new workflow. The trigger element triggers a :ref:`process-element-start-request` element, which has an enabled triggered start mechanism. On call, the trigger element creates a case and a task with the defined configuration on the :ref:`process-element-start-request`. element. The new created task is returned to the Trigger element."
-msgstr "トリガー要素を使用して、新しいワークフローを開始できます。 トリガー要素は、トリガーによる開始メカニズムが有効 :ref:`process-element-start-request` 要素をトリガーします。"
+msgstr "トリガー要素を使用して、新しいワークフローを開始できます。 トリガー要素は、トリガーによる開始メカニズムが有効 :ref:`process-element-start-request` 要素をトリガーします。 :ref:`process-element-start-request`"
 
 #: ../../source/designer-guide/process-modeling/process-elements/trigger-step.rst:20
 msgid "On call, after the creation of the new case and task, the workflow goes ahead through the process. When the created task starts (some time later, by user interaction or automatically by the system), the process starts at the *Triggered Start* element."


### PR DESCRIPTION
I think this warning is valid. In the original version (EN) the same reference is mentioned two times. In the translated version it is only used once. This text needs to be translated once again. 

I think this version is better, rather than having any special exclude.