### PR TITLE
fix: unify po files format in build with weblate

### DIFF
--- a/.github/workflows/po.yml
+++ b/.github/workflows/po.yml
@@ -38,6 +38,7 @@ jobs:
             tail -n +$new_header_end "$po" > /tmp/body
             cat /tmp/old_header /tmp/body > "$po"
           fi
+          sed -i -z 's/\n$//' "$po"  # remove empty line at end of file if exists
         done
     - name: Create Pull Request
       if: ${{ env.LOCALE_DIFF != '' }}


### PR DESCRIPTION
Hello there, conflict still happen due to the final new line: our build insert a new line at the end of po file while weblate parsing tool seems remove it ( #247 ).  

Claude give me this line of code to remove final new line of po file in our build 😂

---

Hey, however, when poring over the documentation, I see they recommend [(Read more):](https://docs.weblate.org/en/latest/admin/continuous.html#avoiding-merge-conflicts-by-changing-translation-files-in-weblate-only)

<img width="932" height="282" alt="image" src="https://github.com/user-attachments/assets/dc164a1d-4a38-477f-82f2-43ebd506d2ed" />

Seems like our build should only generate the .pot 
-> weblate will read the .pot template then automatically update the .po files accordingly using the **msgmerge** add-ons [See more](https://docs.weblate.org/en/latest/devel/integration.html#updating-target-language-files), then pushing back to our repo.

That means only weblate manages the changes on .po files.

Just sharing my findings, when having time, you can take a look and share your opinion. 🙏



