### PR TITLE
XIVY-19062 drop 'new-bean-class-wizard'

### DIFF
--- a/source/designer-guide/process-modeling/process-elements/program-interface-activity.rst
+++ b/source/designer-guide/process-modeling/process-elements/program-interface-activity.rst
@@ -78,11 +78,6 @@ allows to configure its execution.
 Implementation
 ---------------
 
-To initiate a custom bean implementation for your third party system, 
-you start most conveniently by using the :ref:`New Class <new-bean-class-wizard>` |add-button| 
-button on the Start Tab.
-The wizard will create a minimal sample implementation that works already. 
-You can then adjust it to your needs.
 
 
 API reference

--- a/source/designer-guide/process-modeling/process-elements/program-start.rst
+++ b/source/designer-guide/process-modeling/process-elements/program-start.rst
@@ -69,15 +69,6 @@ TimerBean
 Implementation
 ---------------
 
-.. _new-bean-class-wizard:
-
-To initiate a custom bean implementation for your third party system, 
-you start most conveniently by using the :ref:`New Class <new-bean-class-wizard>` |add-button| 
-button on the Start Tab.
-The wizard will create a minimal sample implementation that works already. 
-You can then adjust it to your needs.
-
-
 API reference
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/designer-guide/reference/reference.rst
+++ b/source/designer-guide/reference/reference.rst
@@ -52,7 +52,6 @@ Views
 Wizards
 -------
 
--  :ref:`New Bean Class wizard <new-bean-class-wizard>`
 -  :ref:`casemap-new-wizard`
 -  :ref:`data-class-new-wizard`
 -  :ref:`persistence-entity-class-new-wizard`


### PR DESCRIPTION
- the wizard was not ported to VScode after leaving Eclipse